### PR TITLE
feat: implement Phase 4 ballot casting for voters

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -12,6 +12,7 @@
         "@nestjs/common": "^11.0.1",
         "@nestjs/core": "^11.0.1",
         "@nestjs/jwt": "^11.0.2",
+        "@nestjs/mapped-types": "^2.1.1",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
         "@prisma/adapter-pg": "^7.4.2",
@@ -2478,6 +2479,26 @@
       },
       "peerDependencies": {
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+      }
+    },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.1.tgz",
+      "integrity": "sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0 || ^0.15.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/passport": {

--- a/api/package.json
+++ b/api/package.json
@@ -24,6 +24,7 @@
     "@nestjs/common": "^11.0.1",
     "@nestjs/core": "^11.0.1",
     "@nestjs/jwt": "^11.0.2",
+    "@nestjs/mapped-types": "^2.1.1",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
     "@prisma/adapter-pg": "^7.4.2",
@@ -32,10 +33,10 @@
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
+    "dotenv": "^17.3.1",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.2",
-    "dotenv": "^17.3.1",
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
@@ -75,9 +76,16 @@
     ],
     "rootDir": "src",
     "testRegex": ".*\\.spec\\.ts$",
-    "extensionsToTreatAsEsm": [".ts"],
+    "extensionsToTreatAsEsm": [
+      ".ts"
+    ],
     "transform": {
-      "^.+\\.(t|j)s$": ["ts-jest", { "useESM": true }]
+      "^.+\\.(t|j)s$": [
+        "ts-jest",
+        {
+          "useESM": true
+        }
+      ]
     },
     "collectCoverageFrom": [
       "**/*.(t|j)s"

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -7,7 +7,181 @@ datasource db {
   provider = "postgresql"
 }
 
-// ─── Enums ────────────────────────────────────────────────────────────────────
+model Region {
+  id               String        @id @default(uuid()) @db.Uuid
+  name             String        @unique
+  code             String        @unique
+  population       Int
+  created_at       DateTime      @default(now())
+  departements     Departement[]
+  elections_scoped Election[]    @relation("RegionElections")
+
+  @@map("regions")
+}
+
+model Departement {
+  id               String     @id @default(uuid()) @db.Uuid
+  region_id        String     @db.Uuid
+  name             String
+  code             String     @unique
+  population       Int
+  created_at       DateTime   @default(now())
+  communes         Commune[]
+  region           Region     @relation(fields: [region_id], references: [id])
+  elections_scoped Election[] @relation("DepartementElections")
+
+  @@map("departements")
+}
+
+model Commune {
+  id               String         @id @default(uuid()) @db.Uuid
+  departement_id   String         @db.Uuid
+  name             String
+  population       Int
+  created_at       DateTime       @default(now())
+  bureaux          BureauDeVote[]
+  departement      Departement    @relation(fields: [departement_id], references: [id])
+  elections_scoped Election[]     @relation("CommuneElections")
+  users            User[]
+
+  @@map("communes")
+}
+
+model BureauDeVote {
+  id         String   @id @default(uuid()) @db.Uuid
+  commune_id String   @db.Uuid
+  name       String
+  address    String?
+  capacity   Int?
+  created_at DateTime @default(now())
+  commune    Commune  @relation(fields: [commune_id], references: [id])
+  users      User[]
+
+  @@map("bureaux_de_vote")
+}
+
+model User {
+  id                String        @id @default(uuid()) @db.Uuid
+  national_id       String        @unique
+  email             String        @unique
+  password_hash     String
+  role              Role          @default(VOTER)
+  created_at        DateTime      @default(now())
+  updated_at        DateTime      @updatedAt
+  bureau_de_vote_id String?       @db.Uuid
+  commune_id        String        @db.Uuid
+  date_of_birth     DateTime      @db.Date
+  first_name        String
+  last_name         String
+  otp_attempts      Int           @default(0)
+  otp_code          String?
+  otp_expires_at    DateTime?
+  phone_number      String        @unique
+  status            UserStatus    @default(PENDING_OTP)
+  bureau            BureauDeVote? @relation(fields: [bureau_de_vote_id], references: [id])
+  commune           Commune       @relation(fields: [commune_id], references: [id])
+  votes             Vote[]
+
+  @@map("users")
+}
+
+model PoliticalParty {
+  id           String      @id @default(uuid()) @db.Uuid
+  name         String      @unique
+  acronym      String      @unique
+  logo_url     String?
+  founded_year Int?
+  description  String?
+  created_at   DateTime    @default(now())
+  candidates   Candidate[]
+
+  @@map("political_parties")
+}
+
+model Election {
+  id                   String           @id @default(uuid()) @db.Uuid
+  title                String
+  type                 ElectionType
+  description          String?
+  start_time           DateTime
+  end_time             DateTime
+  status               ElectionStatus   @default(BROUILLON)
+  created_at           DateTime         @default(now())
+  updated_at           DateTime         @updatedAt
+  geographic_scope     GeographicScope  @default(NATIONAL)
+  parent_election_id   String?          @db.Uuid
+  round                Int              @default(1)
+  scope_commune_id     String?          @db.Uuid
+  scope_departement_id String?          @db.Uuid
+  scope_region_id      String?          @db.Uuid
+  candidates           Candidate[]
+  results              ElectionResult[]
+  parent_election      Election?        @relation("ElectionRounds", fields: [parent_election_id], references: [id])
+  child_elections      Election[]       @relation("ElectionRounds")
+  scope_commune        Commune?         @relation("CommuneElections", fields: [scope_commune_id], references: [id])
+  scope_departement    Departement?     @relation("DepartementElections", fields: [scope_departement_id], references: [id])
+  scope_region         Region?          @relation("RegionElections", fields: [scope_region_id], references: [id])
+  votes                Vote[]
+
+  @@map("elections")
+}
+
+model Candidate {
+  id                    String           @id @default(uuid()) @db.Uuid
+  election_id           String           @db.Uuid
+  first_name            String
+  last_name             String
+  photo_url             String?
+  created_at            DateTime         @default(now())
+  age_verified          Boolean          @default(false)
+  biography             String?
+  criminal_record_clear Boolean          @default(false)
+  nationality_verified  Boolean          @default(false)
+  party_id              String?          @db.Uuid
+  program_url           String?
+  running_mate_id       String?          @db.Uuid
+  election              Election         @relation(fields: [election_id], references: [id])
+  party                 PoliticalParty?  @relation(fields: [party_id], references: [id])
+  running_mate          Candidate?       @relation("RunningMate", fields: [running_mate_id], references: [id])
+  mate_of               Candidate[]      @relation("RunningMate")
+  results               ElectionResult[]
+  votes                 Vote[]
+
+  @@map("candidates")
+}
+
+model Vote {
+  id             String    @id @default(uuid()) @db.Uuid
+  election_id    String    @db.Uuid
+  user_id        String    @db.Uuid
+  candidate_id   String    @db.Uuid
+  encrypted_vote String
+  receipt_code   String    @unique
+  created_at     DateTime  @default(now())
+  candidate      Candidate @relation(fields: [candidate_id], references: [id])
+  election       Election  @relation(fields: [election_id], references: [id])
+  user           User      @relation(fields: [user_id], references: [id])
+
+  @@unique([user_id, election_id])
+  @@map("votes")
+}
+
+model ElectionResult {
+  id                 String          @id @default(uuid()) @db.Uuid
+  election_id        String          @db.Uuid
+  candidate_id       String          @db.Uuid
+  scope              GeographicScope
+  scope_id           String?         @db.Uuid
+  votes_count        Int             @default(0)
+  registered_voters  Int             @default(0)
+  turnout_percentage Decimal         @db.Decimal(5, 2)
+  computed_at        DateTime        @default(now())
+  candidate          Candidate       @relation(fields: [candidate_id], references: [id])
+  election           Election        @relation(fields: [election_id], references: [id])
+
+  @@unique([election_id, candidate_id, scope, scope_id])
+  @@map("election_results")
+}
 
 enum Role {
   VOTER
@@ -42,219 +216,4 @@ enum GeographicScope {
   REGIONAL
   DEPARTEMENTAL
   COMMUNAL
-}
-
-// ─── Geography (Côte d'Ivoire hierarchy) ──────────────────────────────────────
-
-model Region {
-  id         String   @id @default(uuid()) @db.Uuid
-  name       String   @unique
-  code       String   @unique
-  population Int
-  created_at DateTime @default(now())
-
-  departements     Departement[]
-  elections_scoped Election[]    @relation("RegionElections")
-
-  @@map("regions")
-}
-
-model Departement {
-  id         String   @id @default(uuid()) @db.Uuid
-  region_id  String   @db.Uuid
-  name       String
-  code       String   @unique
-  population Int
-  created_at DateTime @default(now())
-
-  region           Region     @relation(fields: [region_id], references: [id])
-  communes         Commune[]
-  elections_scoped Election[] @relation("DepartementElections")
-
-  @@map("departements")
-}
-
-model Commune {
-  id             String   @id @default(uuid()) @db.Uuid
-  departement_id String   @db.Uuid
-  name           String
-  population     Int
-  created_at     DateTime @default(now())
-
-  departement      Departement    @relation(fields: [departement_id], references: [id])
-  bureaux          BureauDeVote[]
-  users            User[]
-  elections_scoped Election[]     @relation("CommuneElections")
-
-  @@map("communes")
-}
-
-model BureauDeVote {
-  id         String   @id @default(uuid()) @db.Uuid
-  commune_id String   @db.Uuid
-  name       String
-  address    String?
-  capacity   Int?
-  created_at DateTime @default(now())
-
-  commune Commune @relation(fields: [commune_id], references: [id])
-  users   User[]
-
-  @@map("bureaux_de_vote")
-}
-
-// ─── Users ────────────────────────────────────────────────────────────────────
-
-model User {
-  id            String     @id @default(uuid()) @db.Uuid
-  national_id   String     @unique
-  email         String     @unique
-  password_hash String
-  role          Role       @default(VOTER)
-  status        UserStatus @default(PENDING_OTP)
-
-  first_name    String
-  last_name     String
-  date_of_birth DateTime  @db.Date
-  phone_number  String    @unique
-
-  commune_id        String  @db.Uuid
-  bureau_de_vote_id String? @db.Uuid
-
-  // Mock OTP fields
-  otp_code       String?
-  otp_expires_at DateTime?
-  otp_attempts   Int       @default(0)
-
-  created_at DateTime @default(now())
-  updated_at DateTime @updatedAt
-
-  commune Commune       @relation(fields: [commune_id], references: [id])
-  bureau  BureauDeVote? @relation(fields: [bureau_de_vote_id], references: [id])
-  votes   Vote[]
-
-  @@map("users")
-}
-
-// ─── Political Parties ────────────────────────────────────────────────────────
-
-model PoliticalParty {
-  id           String   @id @default(uuid()) @db.Uuid
-  name         String   @unique
-  acronym      String   @unique
-  logo_url     String?
-  founded_year Int?
-  description  String?
-  created_at   DateTime @default(now())
-
-  candidates Candidate[]
-
-  @@map("political_parties")
-}
-
-// ─── Elections ────────────────────────────────────────────────────────────────
-
-model Election {
-  id               String          @id @default(uuid()) @db.Uuid
-  title            String
-  type             ElectionType
-  description      String?
-  status           ElectionStatus  @default(BROUILLON)
-  geographic_scope GeographicScope @default(NATIONAL)
-
-  scope_region_id      String? @db.Uuid
-  scope_departement_id String? @db.Uuid
-  scope_commune_id     String? @db.Uuid
-
-  start_time DateTime
-  end_time   DateTime
-
-  round              Int     @default(1)
-  parent_election_id String? @db.Uuid
-
-  created_at DateTime @default(now())
-  updated_at DateTime @updatedAt
-
-  scope_region      Region?      @relation("RegionElections", fields: [scope_region_id], references: [id])
-  scope_departement Departement? @relation("DepartementElections", fields: [scope_departement_id], references: [id])
-  scope_commune     Commune?     @relation("CommuneElections", fields: [scope_commune_id], references: [id])
-  parent_election   Election?    @relation("ElectionRounds", fields: [parent_election_id], references: [id])
-  child_elections   Election[]   @relation("ElectionRounds")
-
-  candidates Candidate[]
-  votes      Vote[]
-  results    ElectionResult[]
-
-  @@map("elections")
-}
-
-model Candidate {
-  id          String  @id @default(uuid()) @db.Uuid
-  election_id String  @db.Uuid
-  party_id    String? @db.Uuid
-
-  first_name  String
-  last_name   String
-  photo_url   String?
-  biography   String?
-  program_url String?
-
-  running_mate_id String? @db.Uuid
-
-  nationality_verified  Boolean @default(false)
-  criminal_record_clear Boolean @default(false)
-  age_verified          Boolean @default(false)
-
-  created_at DateTime @default(now())
-
-  election     Election        @relation(fields: [election_id], references: [id])
-  party        PoliticalParty? @relation(fields: [party_id], references: [id])
-  running_mate Candidate?      @relation("RunningMate", fields: [running_mate_id], references: [id])
-  mate_of      Candidate[]     @relation("RunningMate")
-
-  votes   Vote[]
-  results ElectionResult[]
-
-  @@map("candidates")
-}
-
-// ─── Votes ────────────────────────────────────────────────────────────────────
-
-model Vote {
-  id             String   @id @default(uuid()) @db.Uuid
-  election_id    String   @db.Uuid
-  user_id        String   @db.Uuid
-  candidate_id   String   @db.Uuid
-  encrypted_vote String
-  receipt_code   String   @unique
-  created_at     DateTime @default(now())
-
-  election  Election  @relation(fields: [election_id], references: [id])
-  user      User      @relation(fields: [user_id], references: [id])
-  candidate Candidate @relation(fields: [candidate_id], references: [id])
-
-  @@unique([user_id, election_id])
-  @@map("votes")
-}
-
-// ─── Results (auto-computed, never manually entered) ──────────────────────────
-
-model ElectionResult {
-  id           String          @id @default(uuid()) @db.Uuid
-  election_id  String          @db.Uuid
-  candidate_id String          @db.Uuid
-  scope        GeographicScope
-  scope_id     String?         @db.Uuid
-
-  votes_count        Int     @default(0)
-  registered_voters  Int     @default(0)
-  turnout_percentage Decimal @db.Decimal(5, 2)
-
-  computed_at DateTime @default(now())
-
-  election  Election  @relation(fields: [election_id], references: [id])
-  candidate Candidate @relation(fields: [candidate_id], references: [id])
-
-  @@unique([election_id, candidate_id, scope, scope_id])
-  @@map("election_results")
 }

--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -1,4 +1,5 @@
 import 'dotenv/config';
+import * as crypto from 'crypto';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { PrismaClient } from '../generated/prisma/client.js';
 import * as bcrypt from 'bcrypt';
@@ -785,100 +786,465 @@ async function main() {
   });
 
   // ══════════════════════════════════════════════════════════════════════════
-  //  ELECTIONS & CANDIDATES
+  //  ELECTIONS, CANDIDATES, USERS & VOTES
   // ══════════════════════════════════════════════════════════════════════════
 
   const now = new Date();
-  const votingStart = new Date(now.getTime() - 2 * 60 * 60 * 1000);
-  const votingEnd   = new Date(now.getTime() + 10 * 60 * 60 * 1000);
 
-  async function upsertElection(title: string, data: object) {
+  const dAgo  = (n: number) => new Date(now.getTime() - n * 86_400_000);
+  const dFwd  = (n: number) => new Date(now.getTime() + n * 86_400_000);
+  const hAgo  = (n: number) => new Date(now.getTime() - n * 3_600_000);
+  const hFwd  = (n: number) => new Date(now.getTime() + n * 3_600_000);
+
+  // Status is always derived from the time window — re-seeding corrects stale records
+  const derivedStatus = (start: Date, end: Date): string => {
+    if (now < start) return 'OUVERT';
+    if (now > end)   return 'CLOS';
+    return 'EN_COURS';
+  };
+
+  async function upsertElection(title: string, data: Record<string, unknown>) {
     const existing = await prisma.election.findFirst({ where: { title } });
-    if (existing) return existing;
-    return prisma.election.create({ data: data as any });
+    if (existing) return prisma.election.update({ where: { id: existing.id }, data });
+    return prisma.election.create({ data: { title, ...data } as any });
   }
-  async function upsertCandidate(election_id: string, first_name: string, last_name: string, data: object) {
+
+  async function upsertCandidate(
+    election_id: string, first_name: string, last_name: string, data: object,
+  ) {
     const existing = await prisma.candidate.findFirst({ where: { election_id, first_name, last_name } });
     if (existing) return existing;
     return prisma.candidate.create({ data: { election_id, first_name, last_name, ...data } as any });
   }
 
-  const presidentielle = await upsertElection('Élection Présidentielle 2026', {
-    title: 'Élection Présidentielle 2026',
-    type: 'PRESIDENTIELLE', status: 'EN_COURS', geographic_scope: 'NATIONAL',
+  async function seedVote(user_id: string, election_id: string, candidate_id: string) {
+    const exists = await prisma.vote.findUnique({
+      where: { user_id_election_id: { user_id, election_id } },
+    });
+    if (exists) return exists;
+    return prisma.vote.create({
+      data: {
+        user_id, election_id, candidate_id,
+        encrypted_vote: `seed:${Buffer.from(JSON.stringify({ election_id, candidate_id })).toString('base64')}`,
+        receipt_code: crypto.randomUUID(),
+      },
+    });
+  }
+
+  // ══════════════════════════════════════════════════════════════════════════
+  //  ELECTIONS — PUBLIE (ended, results published)
+  // ══════════════════════════════════════════════════════════════════════════
+
+  // 1. Présidentielle 2025 — NATIONAL — ended 120 days ago
+  const pres2025 = await upsertElection('Élection Présidentielle 2025', {
+    type: 'PRESIDENTIELLE', status: 'PUBLIE', geographic_scope: 'NATIONAL',
     description: "Élection du Président de la République de Côte d'Ivoire pour un mandat de 5 ans.",
-    start_time: votingStart, end_time: votingEnd,
+    start_time: dAgo(120), end_time: dAgo(119),
   });
-  await upsertCandidate(presidentielle.id, 'Alassane', 'Ouattara', { party_id: rhdp.id, nationality_verified: true, criminal_record_clear: true, age_verified: true });
-  await upsertCandidate(presidentielle.id, 'Tidjane', 'Thiam',    { party_id: pdci.id, nationality_verified: true, criminal_record_clear: true, age_verified: true });
-  await upsertCandidate(presidentielle.id, 'Laurent', 'Gbagbo',   { party_id: ppaci.id, nationality_verified: true, criminal_record_clear: true, age_verified: true });
-  await upsertCandidate(presidentielle.id, 'Kouadio', 'Konan Bertin', { party_id: independant.id, nationality_verified: true, criminal_record_clear: true, age_verified: true });
+  const p25_ouattara = await upsertCandidate(pres2025.id, 'Alassane', 'Ouattara',     { party_id: rhdp.id,        nationality_verified: true, criminal_record_clear: true, age_verified: true, biography: "Président sortant, ancien Premier Ministre et économiste international." });
+  const p25_thiam    = await upsertCandidate(pres2025.id, 'Tidjane',  'Thiam',        { party_id: pdci.id,        nationality_verified: true, criminal_record_clear: true, age_verified: true, biography: "Ancien PDG de Credit Suisse, candidat du PDCI-RDA." });
+  const p25_gbagbo   = await upsertCandidate(pres2025.id, 'Laurent',  'Gbagbo',       { party_id: ppaci.id,       nationality_verified: true, criminal_record_clear: true, age_verified: true, biography: "Ancien Président de la République, fondateur du PPA-CI." });
+  const p25_kkb      = await upsertCandidate(pres2025.id, 'Kouadio',  'Konan Bertin', { party_id: independant.id, nationality_verified: true, criminal_record_clear: true, age_verified: true, biography: "Candidat indépendant, ancien député." });
+
+  // 2. Référendum Nouvelle Constitution 2025 — NATIONAL — ended 60 days ago
+  const ref2025 = await upsertElection('Référendum Nouvelle Constitution 2025', {
+    type: 'REFERENDUM', status: 'PUBLIE', geographic_scope: 'NATIONAL',
+    description: "Référendum populaire sur l'adoption de la nouvelle Constitution.",
+    start_time: dAgo(60), end_time: dAgo(59),
+  });
+  const ref_oui = await upsertCandidate(ref2025.id, 'OUI', 'Pour la réforme',   { nationality_verified: true, criminal_record_clear: true, age_verified: true });
+  const ref_non = await upsertCandidate(ref2025.id, 'NON', 'Contre la réforme', { nationality_verified: true, criminal_record_clear: true, age_verified: true });
+
+  // ══════════════════════════════════════════════════════════════════════════
+  //  ELECTIONS — CLOS (ended, results pending)
+  // ══════════════════════════════════════════════════════════════════════════
+
+  // 3. Régionales District Abidjan 2026 — REGIONAL — ended 14 days ago
+  const regAbj = await upsertElection('Régionales District Abidjan 2026', {
+    type: 'REGIONALES', status: derivedStatus(dAgo(14), dAgo(13)), geographic_scope: 'REGIONAL',
+    description: "Élections régionales pour le District Autonome d'Abidjan.",
+    start_time: dAgo(14), end_time: dAgo(13),
+    scope_region_id: rAbidjan.id,
+  });
+  const rAbj_diallo  = await upsertCandidate(regAbj.id, 'Ibrahim',   'Diallo',  { party_id: rhdp.id,        nationality_verified: true, criminal_record_clear: true, age_verified: true });
+  const rAbj_lago    = await upsertCandidate(regAbj.id, 'Henriette', 'Lago',    { party_id: pdci.id,        nationality_verified: true, criminal_record_clear: true, age_verified: true });
+  const rAbj_gnamien = await upsertCandidate(regAbj.id, 'Sylvain',   'Gnamien', { party_id: independant.id, nationality_verified: true, criminal_record_clear: true, age_verified: true });
+
+  // 4. Législatives Cocody 2026 — COMMUNAL — ended 5 days ago
+  const legCoc = await upsertElection('Législatives Cocody 2026', {
+    type: 'LEGISLATIVES', status: derivedStatus(dAgo(5), dAgo(4)), geographic_scope: 'COMMUNAL',
+    description: "Élections législatives pour la circonscription de Cocody.",
+    start_time: dAgo(5), end_time: dAgo(4),
+    scope_commune_id: cCocody.id,
+  });
+  const lCoc_kone  = await upsertCandidate(legCoc.id, 'Marie-Josée',   'Koné',  { party_id: rhdp.id,        nationality_verified: true, criminal_record_clear: true, age_verified: true });
+  const lCoc_brou  = await upsertCandidate(legCoc.id, 'Jean-Baptiste', 'Brou',  { party_id: pdci.id,        nationality_verified: true, criminal_record_clear: true, age_verified: true });
+  const lCoc_sylla = await upsertCandidate(legCoc.id, 'Awa',           'Sylla', { party_id: independant.id, nationality_verified: true, criminal_record_clear: true, age_verified: true });
+
+  // 5. Municipales Abobo 2026 — COMMUNAL — ended 3 days ago
+  const munAbo = await upsertElection('Municipales Abobo 2026', {
+    type: 'MUNICIPALES', status: derivedStatus(dAgo(3), dAgo(2)), geographic_scope: 'COMMUNAL',
+    description: "Élections municipales pour la commune d'Abobo.",
+    start_time: dAgo(3), end_time: dAgo(2),
+    scope_commune_id: cAbobo.id,
+  });
+  const mAbo_bamba = await upsertCandidate(munAbo.id, 'Adama',     'Bamba', { party_id: rhdp.id,        nationality_verified: true, criminal_record_clear: true, age_verified: true });
+  const mAbo_toure = await upsertCandidate(munAbo.id, 'Fatoumata', 'Touré', { party_id: ppaci.id,       nationality_verified: true, criminal_record_clear: true, age_verified: true });
+  const mAbo_kone  = await upsertCandidate(munAbo.id, 'Seydou',    'Koné',  { party_id: independant.id, nationality_verified: true, criminal_record_clear: true, age_verified: true });
+
+  // 6. Régionales Gbêkê 2025 — REGIONAL (Bouaké) — ended 30 days ago
+  const regGbeOld = await upsertElection('Régionales Gbêkê 2025', {
+    type: 'REGIONALES', status: derivedStatus(dAgo(30), dAgo(29)), geographic_scope: 'REGIONAL',
+    description: "Élections régionales pour la région du Gbêkê (cycle 2025).",
+    start_time: dAgo(30), end_time: dAgo(29),
+    scope_region_id: rGbeke.id,
+  });
+  const rGbeO_kone     = await upsertCandidate(regGbeOld.id, 'Issouf',    'Koné',      { party_id: rhdp.id,        nationality_verified: true, criminal_record_clear: true, age_verified: true });
+  const rGbeO_coulibaly = await upsertCandidate(regGbeOld.id, 'Dramane',  'Coulibaly', { party_id: pdci.id,        nationality_verified: true, criminal_record_clear: true, age_verified: true });
+  const rGbeO_sanogo   = await upsertCandidate(regGbeOld.id, 'Mariam',    'Sanogo',    { party_id: independant.id, nationality_verified: true, criminal_record_clear: true, age_verified: true });
+
+  // ══════════════════════════════════════════════════════════════════════════
+  //  ELECTIONS — EN_COURS (active now)
+  // ══════════════════════════════════════════════════════════════════════════
+
+  // 7. Élections Législatives Nationales 2026 — NATIONAL — active (−3h → +8h)
+  const legNat = await upsertElection('Élections Législatives Nationales 2026', {
+    type: 'LEGISLATIVES', status: 'EN_COURS', geographic_scope: 'NATIONAL',
+    description: "Renouvellement de l'ensemble des sièges de l'Assemblée Nationale.",
+    start_time: hAgo(3), end_time: hFwd(8),
+  });
+  const lNat_coulibaly = await upsertCandidate(legNat.id, 'Amadou',    'Coulibaly', { party_id: rhdp.id,        nationality_verified: true, criminal_record_clear: true, age_verified: true });
+  const lNat_dosso     = await upsertCandidate(legNat.id, 'Mariam',    'Dosso',     { party_id: pdci.id,        nationality_verified: true, criminal_record_clear: true, age_verified: true });
+  const lNat_bictogo   = await upsertCandidate(legNat.id, 'Adama',     'Bictogo',   { party_id: ppaci.id,       nationality_verified: true, criminal_record_clear: true, age_verified: true });
+  const lNat_soro      = await upsertCandidate(legNat.id, 'Guillaume', 'Soro',      { party_id: independant.id, nationality_verified: true, criminal_record_clear: true, age_verified: true });
+
+  // 8. Régionales Gbêkê 2026 — REGIONAL (Bouaké) — active (−2h → +10h)
+  const regGbe = await upsertElection('Régionales Gbêkê 2026', {
+    type: 'REGIONALES', status: 'EN_COURS', geographic_scope: 'REGIONAL',
+    description: "Élections régionales pour la région du Gbêkê.",
+    start_time: hAgo(2), end_time: hFwd(10),
+    scope_region_id: rGbeke.id,
+  });
+  const rGbe_navigué   = await upsertCandidate(regGbe.id, 'Koné',  'Navigué',   { party_id: rhdp.id,        nationality_verified: true, criminal_record_clear: true, age_verified: true });
+  const rGbe_coulibaly = await upsertCandidate(regGbe.id, 'Yves',  'Coulibaly', { party_id: pdci.id,        nationality_verified: true, criminal_record_clear: true, age_verified: true });
+  const rGbe_sanogo    = await upsertCandidate(regGbe.id, 'Aïssa', 'Sanogo',    { party_id: independant.id, nationality_verified: true, criminal_record_clear: true, age_verified: true });
+
+  // 9. Municipales Yopougon 2026 — COMMUNAL — active (−2h → +10h)
+  const munYop = await upsertElection('Municipales Yopougon 2026', {
+    type: 'MUNICIPALES', status: 'EN_COURS', geographic_scope: 'COMMUNAL',
+    description: "Élections municipales pour la commune de Yopougon.",
+    start_time: hAgo(2), end_time: hFwd(10),
+    scope_commune_id: cYopougon.id,
+  });
+  const mYop_ouattara = await upsertCandidate(munYop.id, 'Gnénéfoly', 'Ouattara', { party_id: rhdp.id,        nationality_verified: true, criminal_record_clear: true, age_verified: true });
+  const mYop_kobenan  = await upsertCandidate(munYop.id, 'Séraphin',  'Kobenan',  { party_id: pdci.id,        nationality_verified: true, criminal_record_clear: true, age_verified: true });
+  const mYop_diallo   = await upsertCandidate(munYop.id, 'Fatou',     'Diallo',   { party_id: ppaci.id,       nationality_verified: true, criminal_record_clear: true, age_verified: true });
+  const mYop_traore   = await upsertCandidate(munYop.id, 'Moussa',    'Traoré',   { party_id: independant.id, nationality_verified: true, criminal_record_clear: true, age_verified: true });
+
+  // 10. Référendum Réforme Électorale 2026 — NATIONAL — active (−1h → +12h)
+  const refElec = await upsertElection('Référendum Réforme Électorale 2026', {
+    type: 'REFERENDUM', status: 'EN_COURS', geographic_scope: 'NATIONAL',
+    description: "Référendum sur la réforme du code électoral et l'introduction du vote électronique.",
+    start_time: hAgo(1), end_time: hFwd(12),
+  });
+  const refE_oui = await upsertCandidate(refElec.id, 'OUI', 'Pour la réforme électorale',   { nationality_verified: true, criminal_record_clear: true, age_verified: true });
+  const refE_non = await upsertCandidate(refElec.id, 'NON', 'Contre la réforme électorale', { nationality_verified: true, criminal_record_clear: true, age_verified: true });
+
+  // ══════════════════════════════════════════════════════════════════════════
+  //  ELECTIONS — OUVERT (upcoming)
+  // ══════════════════════════════════════════════════════════════════════════
+
+  // 11. Municipales Cocody 2026 — COMMUNAL — starts in 2 days
+  const munCoc = await upsertElection('Municipales Cocody 2026', {
+    type: 'MUNICIPALES', status: derivedStatus(dFwd(2), dFwd(3)), geographic_scope: 'COMMUNAL',
+    description: "Élections municipales pour la commune de Cocody.",
+    start_time: dFwd(2), end_time: dFwd(3),
+    scope_commune_id: cCocody.id,
+  });
+  await upsertCandidate(munCoc.id, 'Jean-Marc', 'Yacé',   { party_id: rhdp.id,        nationality_verified: true, criminal_record_clear: true, age_verified: true });
+  await upsertCandidate(munCoc.id, 'Estelle',   'Assi',   { party_id: pdci.id,        nationality_verified: true, criminal_record_clear: true, age_verified: true });
+  await upsertCandidate(munCoc.id, 'Romuald',   'Akpata', { party_id: independant.id, nationality_verified: true, criminal_record_clear: true, age_verified: true });
+
+  // 12. Référendum Réforme Foncière 2026 — NATIONAL — starts in 7 days
+  const refFonc = await upsertElection('Référendum Réforme Foncière 2026', {
+    type: 'REFERENDUM', status: derivedStatus(dFwd(7), dFwd(8)), geographic_scope: 'NATIONAL',
+    description: "Référendum sur la réforme de la politique foncière rurale.",
+    start_time: dFwd(7), end_time: dFwd(8),
+  });
+  await upsertCandidate(refFonc.id, 'OUI', 'Pour la réforme foncière',   { nationality_verified: true, criminal_record_clear: true, age_verified: true });
+  await upsertCandidate(refFonc.id, 'NON', 'Contre la réforme foncière', { nationality_verified: true, criminal_record_clear: true, age_verified: true });
+
+  // 13. Présidentielle 2026 — NATIONAL — starts in 15 days (brouillon → open campaign)
+  const pres2026 = await upsertElection('Élection Présidentielle 2026', {
+    type: 'PRESIDENTIELLE', status: derivedStatus(dFwd(15), dFwd(16)), geographic_scope: 'NATIONAL',
+    description: "Élection du Président de la République — scrutin quinquennal 2026.",
+    start_time: dFwd(15), end_time: dFwd(16),
+  });
+  await upsertCandidate(pres2026.id, 'Alassane', 'Ouattara',     { party_id: rhdp.id,        nationality_verified: true, criminal_record_clear: true, age_verified: true });
+  await upsertCandidate(pres2026.id, 'Tidjane',  'Thiam',        { party_id: pdci.id,        nationality_verified: true, criminal_record_clear: true, age_verified: true });
+  await upsertCandidate(pres2026.id, 'Laurent',  'Gbagbo',       { party_id: ppaci.id,       nationality_verified: true, criminal_record_clear: true, age_verified: true });
+  await upsertCandidate(pres2026.id, 'Kouadio',  'Konan Bertin', { party_id: independant.id, nationality_verified: true, criminal_record_clear: true, age_verified: true });
+
+  console.log('✓ 13 elections and candidates seeded');
 
   // ══════════════════════════════════════════════════════════════════════════
   //  USERS
   // ══════════════════════════════════════════════════════════════════════════
 
+  // Extra bureaux for new communes
+  const bAbobo   = await upsertBureau("Mairie d'Abobo",              cAbobo.id,        "Abobo, Abidjan",   800);
+  const bPlateau = await upsertBureau("Hôtel de Ville du Plateau",   cPlateau.id,      "Plateau, Abidjan", 300);
+  const bYam2    = await upsertBureau("Mairie de Yamoussoukro",      cYamoussoukro.id, "Yamoussoukro",     400);
+
   const adminHash = await bcrypt.hash('Admin@12345', 10);
   const voterHash = await bcrypt.hash('Voter@12345', 10);
 
-  await prisma.user.upsert({
-    where: { email: 'admin@agora.gov' },
-    update: {},
-    create: {
-      national_id: 'ADMIN001', email: 'admin@agora.gov', password_hash: adminHash,
-      role: 'ADMIN', status: 'ACTIVE',
-      first_name: 'Super', last_name: 'Administrateur',
-      date_of_birth: new Date('1980-01-01'), phone_number: '+2250700000000',
-      commune_id: cCocody.id, bureau_de_vote_id: bCocody.id,
-    },
-  });
+  // ── Admin ────────────────────────────────────────────────────────────────
+  await prisma.user.upsert({ where: { email: 'admin@agora.gov' }, update: {}, create: {
+    national_id: 'ADMIN001', email: 'admin@agora.gov', password_hash: adminHash,
+    role: 'ADMIN', status: 'ACTIVE',
+    first_name: 'Super', last_name: 'Administrateur',
+    date_of_birth: new Date('1980-01-01'), phone_number: '+2250700000000',
+    commune_id: cCocody.id, bureau_de_vote_id: bCocody.id,
+  }});
 
-  await prisma.user.upsert({
-    where: { email: 'kouassi@example.com' },
-    update: {},
-    create: {
-      national_id: 'CI0012345678', email: 'kouassi@example.com', password_hash: voterHash,
-      role: 'VOTER', status: 'ACTIVE',
-      first_name: 'Kouassi', last_name: 'Amani',
-      date_of_birth: new Date('1990-04-15'), phone_number: '+2250701234567',
-      commune_id: cCocody.id, bureau_de_vote_id: bCocody.id,
-    },
-  });
+  // ── Voters — Cocody (Abidjan) ────────────────────────────────────────────
+  const uKouassi = await prisma.user.upsert({ where: { email: 'kouassi@example.com' }, update: {}, create: {
+    national_id: 'CI0012345678', email: 'kouassi@example.com', password_hash: voterHash,
+    role: 'VOTER', status: 'ACTIVE',
+    first_name: 'Kouassi', last_name: 'Amani',
+    date_of_birth: new Date('1990-04-15'), phone_number: '+2250701234567',
+    commune_id: cCocody.id, bureau_de_vote_id: bCocody.id,
+  }});
+  const uPierre = await prisma.user.upsert({ where: { email: 'pierre@example.com' }, update: {}, create: {
+    national_id: 'CI0023456789', email: 'pierre@example.com', password_hash: voterHash,
+    role: 'VOTER', status: 'ACTIVE',
+    first_name: 'Pierre', last_name: 'Aké',
+    date_of_birth: new Date('1985-07-20'), phone_number: '+2250701234568',
+    commune_id: cCocody.id, bureau_de_vote_id: bCocody.id,
+  }});
+  const uRachel = await prisma.user.upsert({ where: { email: 'rachel@example.com' }, update: {}, create: {
+    national_id: 'CI0034567890', email: 'rachel@example.com', password_hash: voterHash,
+    role: 'VOTER', status: 'ACTIVE',
+    first_name: 'Rachel', last_name: 'Adjoua',
+    date_of_birth: new Date('1992-03-08'), phone_number: '+2250701234569',
+    commune_id: cCocody.id, bureau_de_vote_id: bCocody.id,
+  }});
 
-  await prisma.user.upsert({
-    where: { email: 'aminata@example.com' },
-    update: {},
-    create: {
-      national_id: 'CI0087654321', email: 'aminata@example.com', password_hash: voterHash,
-      role: 'VOTER', status: 'ACTIVE',
-      first_name: 'Aminata', last_name: 'Coulibaly',
-      date_of_birth: new Date('1995-08-22'), phone_number: '+2250702345678',
-      commune_id: cYopougon.id, bureau_de_vote_id: bYopougon.id,
-    },
-  });
+  // ── Voters — Yopougon (Abidjan) ──────────────────────────────────────────
+  const uAminata = await prisma.user.upsert({ where: { email: 'aminata@example.com' }, update: {}, create: {
+    national_id: 'CI0087654321', email: 'aminata@example.com', password_hash: voterHash,
+    role: 'VOTER', status: 'ACTIVE',
+    first_name: 'Aminata', last_name: 'Coulibaly',
+    date_of_birth: new Date('1995-08-22'), phone_number: '+2250702345678',
+    commune_id: cYopougon.id, bureau_de_vote_id: bYopougon.id,
+  }});
+  const uOumar = await prisma.user.upsert({ where: { email: 'oumar@example.com' }, update: {}, create: {
+    national_id: 'CI0098765432', email: 'oumar@example.com', password_hash: voterHash,
+    role: 'VOTER', status: 'ACTIVE',
+    first_name: 'Oumar', last_name: 'Bamba',
+    date_of_birth: new Date('1988-11-15'), phone_number: '+2250702345679',
+    commune_id: cYopougon.id, bureau_de_vote_id: bYopougon.id,
+  }});
+  const uBintou = await prisma.user.upsert({ where: { email: 'bintou@example.com' }, update: {}, create: {
+    national_id: 'CI0109876543', email: 'bintou@example.com', password_hash: voterHash,
+    role: 'VOTER', status: 'ACTIVE',
+    first_name: 'Bintou', last_name: 'Traoré',
+    date_of_birth: new Date('1997-05-30'), phone_number: '+2250702345680',
+    commune_id: cYopougon.id, bureau_de_vote_id: bYopougon.id,
+  }});
 
-  await prisma.user.upsert({
-    where: { email: 'ibrahim@example.com' },
-    update: {},
-    create: {
-      national_id: 'CI0011223344', email: 'ibrahim@example.com', password_hash: voterHash,
-      role: 'VOTER', status: 'ACTIVE',
-      first_name: 'Ibrahim', last_name: 'Koné',
-      date_of_birth: new Date('1988-12-03'), phone_number: '+2250703456789',
-      commune_id: cBouake.id, bureau_de_vote_id: bBouake.id,
-    },
-  });
+  // ── Voters — Abobo (Abidjan) ─────────────────────────────────────────────
+  const uMamadou = await prisma.user.upsert({ where: { email: 'mamadou@example.com' }, update: {}, create: {
+    national_id: 'CI0120987654', email: 'mamadou@example.com', password_hash: voterHash,
+    role: 'VOTER', status: 'ACTIVE',
+    first_name: 'Mamadou', last_name: 'Diallo',
+    date_of_birth: new Date('1991-01-25'), phone_number: '+2250703456790',
+    commune_id: cAbobo.id, bureau_de_vote_id: bAbobo.id,
+  }});
+  const uNana = await prisma.user.upsert({ where: { email: 'nana@example.com' }, update: {}, create: {
+    national_id: 'CI0131098765', email: 'nana@example.com', password_hash: voterHash,
+    role: 'VOTER', status: 'ACTIVE',
+    first_name: 'Nana', last_name: 'Koné',
+    date_of_birth: new Date('1999-09-12'), phone_number: '+2250703456791',
+    commune_id: cAbobo.id, bureau_de_vote_id: bAbobo.id,
+  }});
+  const uDidier = await prisma.user.upsert({ where: { email: 'didier@example.com' }, update: {}, create: {
+    national_id: 'CI0141209876', email: 'didier@example.com', password_hash: voterHash,
+    role: 'VOTER', status: 'ACTIVE',
+    first_name: 'Didier', last_name: 'Gba',
+    date_of_birth: new Date('1986-04-03'), phone_number: '+2250703456792',
+    commune_id: cAbobo.id, bureau_de_vote_id: bAbobo.id,
+  }});
+
+  // ── Voter — Plateau (Abidjan) ────────────────────────────────────────────
+  const uYvonne = await prisma.user.upsert({ where: { email: 'yvonne@example.com' }, update: {}, create: {
+    national_id: 'CI0151320987', email: 'yvonne@example.com', password_hash: voterHash,
+    role: 'VOTER', status: 'ACTIVE',
+    first_name: 'Yvonne', last_name: 'Gnonsoa',
+    date_of_birth: new Date('1983-12-01'), phone_number: '+2250704567890',
+    commune_id: cPlateau.id, bureau_de_vote_id: bPlateau.id,
+  }});
+
+  // ── Voters — Bouaké (Gbêkê) ──────────────────────────────────────────────
+  const uIbrahim = await prisma.user.upsert({ where: { email: 'ibrahim@example.com' }, update: {}, create: {
+    national_id: 'CI0011223344', email: 'ibrahim@example.com', password_hash: voterHash,
+    role: 'VOTER', status: 'ACTIVE',
+    first_name: 'Ibrahim', last_name: 'Koné',
+    date_of_birth: new Date('1988-12-03'), phone_number: '+2250703456789',
+    commune_id: cBouake.id, bureau_de_vote_id: bBouake.id,
+  }});
+  const uAli = await prisma.user.upsert({ where: { email: 'ali@example.com' }, update: {}, create: {
+    national_id: 'CI0161431098', email: 'ali@example.com', password_hash: voterHash,
+    role: 'VOTER', status: 'ACTIVE',
+    first_name: 'Ali', last_name: 'Kourouma',
+    date_of_birth: new Date('1993-06-14'), phone_number: '+2250705678901',
+    commune_id: cBouake.id, bureau_de_vote_id: bBouake.id,
+  }});
+  const uFatima = await prisma.user.upsert({ where: { email: 'fatima@example.com' }, update: {}, create: {
+    national_id: 'CI0171542109', email: 'fatima@example.com', password_hash: voterHash,
+    role: 'VOTER', status: 'ACTIVE',
+    first_name: 'Fatima', last_name: 'Sanogo',
+    date_of_birth: new Date('1996-08-07'), phone_number: '+2250705678902',
+    commune_id: cBouake.id, bureau_de_vote_id: bBouake.id,
+  }});
+
+  // ── Voter — Yamoussoukro ─────────────────────────────────────────────────
+  const uPaul = await prisma.user.upsert({ where: { email: 'paul@example.com' }, update: {}, create: {
+    national_id: 'CI0181653210', email: 'paul@example.com', password_hash: voterHash,
+    role: 'VOTER', status: 'ACTIVE',
+    first_name: 'Paul', last_name: 'Koffi',
+    date_of_birth: new Date('1980-02-28'), phone_number: '+2250706789012',
+    commune_id: cYamoussoukro.id, bureau_de_vote_id: bYam2.id,
+  }});
+
+  console.log('✓ 14 voters + 1 admin seeded');
+
+  // ══════════════════════════════════════════════════════════════════════════
+  //  VOTES  (closed & published elections + partial votes in active ones)
+  //  Eligibility:
+  //    NATIONAL       → everyone
+  //    REGIONAL ABJ   → Cocody, Yopougon, Abobo, Plateau (rAbidjan)
+  //    REGIONAL GBEKE → Bouaké (rGbeke)
+  //    COMMUNAL COC   → Cocody voters
+  //    COMMUNAL YOP   → Yopougon voters
+  //    COMMUNAL ABO   → Abobo voters
+  // ══════════════════════════════════════════════════════════════════════════
+
+  // ── Présidentielle 2025 (NATIONAL — all 13 voters voted) ─────────────────
+  await seedVote(uKouassi.id, pres2025.id, p25_ouattara.id);
+  await seedVote(uPierre.id,  pres2025.id, p25_thiam.id);
+  await seedVote(uRachel.id,  pres2025.id, p25_ouattara.id);
+  await seedVote(uAminata.id, pres2025.id, p25_ouattara.id);
+  await seedVote(uOumar.id,   pres2025.id, p25_gbagbo.id);
+  await seedVote(uBintou.id,  pres2025.id, p25_ouattara.id);
+  await seedVote(uMamadou.id, pres2025.id, p25_ouattara.id);
+  await seedVote(uNana.id,    pres2025.id, p25_thiam.id);
+  await seedVote(uDidier.id,  pres2025.id, p25_kkb.id);
+  await seedVote(uYvonne.id,  pres2025.id, p25_thiam.id);
+  await seedVote(uIbrahim.id, pres2025.id, p25_gbagbo.id);
+  await seedVote(uAli.id,     pres2025.id, p25_ouattara.id);
+  await seedVote(uFatima.id,  pres2025.id, p25_ouattara.id);
+  await seedVote(uPaul.id,    pres2025.id, p25_ouattara.id);
+
+  // ── Référendum Nouvelle Constitution 2025 (NATIONAL — all voted) ──────────
+  await seedVote(uKouassi.id, ref2025.id, ref_oui.id);
+  await seedVote(uPierre.id,  ref2025.id, ref_oui.id);
+  await seedVote(uRachel.id,  ref2025.id, ref_non.id);
+  await seedVote(uAminata.id, ref2025.id, ref_oui.id);
+  await seedVote(uOumar.id,   ref2025.id, ref_oui.id);
+  await seedVote(uBintou.id,  ref2025.id, ref_oui.id);
+  await seedVote(uMamadou.id, ref2025.id, ref_non.id);
+  await seedVote(uNana.id,    ref2025.id, ref_oui.id);
+  await seedVote(uDidier.id,  ref2025.id, ref_oui.id);
+  await seedVote(uYvonne.id,  ref2025.id, ref_oui.id);
+  await seedVote(uIbrahim.id, ref2025.id, ref_non.id);
+  await seedVote(uAli.id,     ref2025.id, ref_oui.id);
+  await seedVote(uFatima.id,  ref2025.id, ref_oui.id);
+  await seedVote(uPaul.id,    ref2025.id, ref_oui.id);
+
+  // ── Régionales Abidjan (REGIONAL rAbidjan — Cocody/Yopougon/Abobo/Plateau) ─
+  await seedVote(uKouassi.id, regAbj.id, rAbj_diallo.id);
+  await seedVote(uPierre.id,  regAbj.id, rAbj_diallo.id);
+  await seedVote(uRachel.id,  regAbj.id, rAbj_lago.id);
+  await seedVote(uAminata.id, regAbj.id, rAbj_diallo.id);
+  await seedVote(uOumar.id,   regAbj.id, rAbj_gnamien.id);
+  await seedVote(uBintou.id,  regAbj.id, rAbj_diallo.id);
+  await seedVote(uMamadou.id, regAbj.id, rAbj_lago.id);
+  await seedVote(uNana.id,    regAbj.id, rAbj_diallo.id);
+  await seedVote(uDidier.id,  regAbj.id, rAbj_gnamien.id);
+  await seedVote(uYvonne.id,  regAbj.id, rAbj_diallo.id);
+
+  // ── Législatives Cocody (COMMUNAL cCocody — Cocody voters only) ───────────
+  await seedVote(uKouassi.id, legCoc.id, lCoc_kone.id);
+  await seedVote(uPierre.id,  legCoc.id, lCoc_brou.id);
+  await seedVote(uRachel.id,  legCoc.id, lCoc_kone.id);
+
+  // ── Municipales Abobo (COMMUNAL cAbobo — Abobo voters only) ─────────────
+  await seedVote(uMamadou.id, munAbo.id, mAbo_bamba.id);
+  await seedVote(uNana.id,    munAbo.id, mAbo_toure.id);
+  await seedVote(uDidier.id,  munAbo.id, mAbo_bamba.id);
+
+  // ── Régionales Gbêkê 2025 (REGIONAL rGbeke — Bouaké voters) ─────────────
+  await seedVote(uIbrahim.id, regGbeOld.id, rGbeO_kone.id);
+  await seedVote(uAli.id,     regGbeOld.id, rGbeO_coulibaly.id);
+  await seedVote(uFatima.id,  regGbeOld.id, rGbeO_kone.id);
+
+  // ── Législatives Nationales 2026 (EN_COURS NATIONAL — partial votes) ─────
+  await seedVote(uKouassi.id, legNat.id, lNat_coulibaly.id);
+  await seedVote(uAminata.id, legNat.id, lNat_dosso.id);
+  await seedVote(uIbrahim.id, legNat.id, lNat_soro.id);
+  await seedVote(uPaul.id,    legNat.id, lNat_coulibaly.id);
+
+  // ── Régionales Gbêkê 2026 (EN_COURS REGIONAL — partial votes) ───────────
+  await seedVote(uIbrahim.id, regGbe.id, rGbe_navigué.id);
+
+  // ── Municipales Yopougon 2026 (EN_COURS COMMUNAL — partial votes) ────────
+  await seedVote(uAminata.id, munYop.id, mYop_ouattara.id);
+  await seedVote(uOumar.id,   munYop.id, mYop_kobenan.id);
+
+  // ── Référendum Réforme Électorale 2026 (EN_COURS NATIONAL — partial) ─────
+  await seedVote(uKouassi.id, refElec.id, refE_oui.id);
+  await seedVote(uAminata.id, refElec.id, refE_oui.id);
+  await seedVote(uIbrahim.id, refElec.id, refE_non.id);
+  await seedVote(uMamadou.id, refElec.id, refE_oui.id);
+
+  console.log('✓ Votes seeded');
 
   // ══════════════════════════════════════════════════════════════════════════
   console.log('\n✓ Seed complete');
-  console.log('─────────────────────────────────────────────────────────────');
+  console.log('─────────────────────────────────────────────────────────────────────');
   console.log('  Geography: 27 regions  |  75 départements  |  ~87 communes');
-  console.log('─────────────────────────────────────────────────────────────');
+  console.log('─────────────────────────────────────────────────────────────────────');
+  console.log('  PUBLIE   Présidentielle 2025              (national, ended -120d)');
+  console.log('  PUBLIE   Référendum Nouvelle Constitution (national, ended -60d)');
+  console.log('  CLOS     Régionales District Abidjan      (regional, ended -14d)');
+  console.log('  CLOS     Législatives Cocody              (communal, ended -5d)');
+  console.log('  CLOS     Municipales Abobo                (communal, ended -3d)');
+  console.log('  CLOS     Régionales Gbêkê 2025            (regional, ended -30d)');
+  console.log('  EN_COURS Législatives Nationales 2026     (national,  -3h → +8h)');
+  console.log('  EN_COURS Régionales Gbêkê 2026            (regional,  -2h → +10h)');
+  console.log('  EN_COURS Municipales Yopougon             (communal,  -2h → +10h)');
+  console.log('  EN_COURS Référendum Réforme Électorale    (national,  -1h → +12h)');
+  console.log('  OUVERT   Municipales Cocody               (communal,  +2d)');
+  console.log('  OUVERT   Référendum Réforme Foncière      (national,  +7d)');
+  console.log('  OUVERT   Présidentielle 2026              (national,  +15d)');
+  console.log('─────────────────────────────────────────────────────────────────────');
   console.log('  Admin:   admin@agora.gov      / Admin@12345');
-  console.log('  Voter 1: kouassi@example.com  / Voter@12345  (Cocody, ABJ)');
-  console.log('  Voter 2: aminata@example.com  / Voter@12345  (Yopougon, ABJ)');
-  console.log('  Voter 3: ibrahim@example.com  / Voter@12345  (Bouaké, GBE)');
-  console.log('─────────────────────────────────────────────────────────────\n');
+  console.log('  Voter:   kouassi@example.com  / Voter@12345  (Cocody)    — can vote legNat, refElec');
+  console.log('  Voter:   aminata@example.com  / Voter@12345  (Yopougon)  — can vote regGbe? No. legNat');
+  console.log('  Voter:   ibrahim@example.com  / Voter@12345  (Bouaké)    — can vote legNat, regGbe');
+  console.log('  Voter:   pierre@example.com   / Voter@12345  (Cocody)');
+  console.log('  Voter:   oumar@example.com    / Voter@12345  (Yopougon)  — can vote munYop');
+  console.log('  Voter:   bintou@example.com   / Voter@12345  (Yopougon)  — can vote munYop, legNat');
+  console.log('  Voter:   mamadou@example.com  / Voter@12345  (Abobo)');
+  console.log('  Voter:   nana@example.com     / Voter@12345  (Abobo)');
+  console.log('  Voter:   didier@example.com   / Voter@12345  (Abobo)');
+  console.log('  Voter:   yvonne@example.com   / Voter@12345  (Plateau)');
+  console.log('  Voter:   ali@example.com      / Voter@12345  (Bouaké)    — can vote regGbe, legNat');
+  console.log('  Voter:   fatima@example.com   / Voter@12345  (Bouaké)    — can vote regGbe, legNat');
+  console.log('  Voter:   paul@example.com     / Voter@12345  (Yamoussoukro)');
+  console.log('─────────────────────────────────────────────────────────────────────\n');
 }
 
 main()

--- a/frontend/app/features/dashboard/VoterBallot.tsx
+++ b/frontend/app/features/dashboard/VoterBallot.tsx
@@ -1,0 +1,423 @@
+import { useState, useEffect } from "react";
+import { useLocation, useNavigate } from "react-router";
+import VoterSidebar from "./VoterSidebar.js";
+
+interface Props {
+  electionId: string;
+  user: { email: string; role: string; first_name?: string; last_name?: string };
+}
+
+interface Candidate {
+  id: string;
+  first_name: string;
+  last_name: string;
+  photo_url?: string;
+  biography?: string;
+  party?: { name: string; acronym: string; logo_url?: string };
+}
+
+interface ElectionDetail {
+  id: string;
+  title: string;
+  type: string;
+  status: string;
+  geographic_scope: string;
+  start_time: string;
+  end_time: string;
+  can_vote: boolean;
+  already_voted: boolean;
+  candidates: Candidate[];
+}
+
+const TYPE_LABELS: Record<string, string> = {
+  PRESIDENTIELLE: "Présidentielle",
+  LEGISLATIVES: "Législatives",
+  REGIONALES: "Régionales",
+  MUNICIPALES: "Municipales",
+  REFERENDUM: "Référendum",
+};
+
+const SCOPE_LABELS: Record<string, string> = {
+  NATIONAL: "National",
+  REGIONAL: "Régional",
+  DEPARTEMENTAL: "Départemental",
+  COMMUNAL: "Communal",
+};
+
+const API = import.meta.env.VITE_API_URL ?? "http://localhost:3000";
+const token = () => localStorage.getItem("voti_token") ?? "";
+
+function fmtDateTime(iso: string) {
+  return new Date(iso).toLocaleString("fr-FR", { day: "2-digit", month: "short", year: "numeric", hour: "2-digit", minute: "2-digit" });
+}
+
+type Step = "select" | "confirm" | "success";
+
+export default function VoterBallot({ electionId, user }: Props) {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const [election, setElection] = useState<ElectionDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const [step, setStep] = useState<Step>("select");
+  const [selected, setSelected] = useState<Candidate | null>(null);
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState("");
+  const [receiptCode, setReceiptCode] = useState("");
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      setError("");
+      try {
+        const res = await fetch(`${API}/elections/${electionId}`, {
+          headers: { Authorization: `Bearer ${token()}` },
+        });
+        if (!res.ok) throw new Error("Impossible de charger cette élection.");
+        setElection(await res.json());
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Erreur inconnue");
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [electionId]);
+
+  const handleSelectCandidate = (candidate: Candidate) => {
+    setSelected(candidate);
+    setSubmitError("");
+    setStep("confirm");
+  };
+
+  const handleConfirm = async () => {
+    if (!selected) return;
+    setSubmitting(true);
+    setSubmitError("");
+    try {
+      const res = await fetch(`${API}/elections/${electionId}/vote`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token()}`,
+        },
+        body: JSON.stringify({ candidate_id: selected.id }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.message ?? "Erreur lors de l'enregistrement du vote.");
+      setReceiptCode(data.receipt_code ?? "");
+      setStep("success");
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : "Erreur inconnue");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div style={{ background: "#fcf9f4", minHeight: "100vh", fontFamily: "Manrope, sans-serif" }}>
+        <VoterSidebar user={user} activePath={location.pathname} />
+        <main style={{ marginLeft: "256px", padding: "2rem", display: "flex", alignItems: "center", justifyContent: "center", minHeight: "100vh" }}>
+          <p style={{ color: "#535f74", fontWeight: 600 }}>Chargement…</p>
+        </main>
+      </div>
+    );
+  }
+
+  if (error || !election) {
+    return (
+      <div style={{ background: "#fcf9f4", minHeight: "100vh", fontFamily: "Manrope, sans-serif" }}>
+        <VoterSidebar user={user} activePath={location.pathname} />
+        <main style={{ marginLeft: "256px", padding: "2rem" }}>
+          <div style={{ padding: "2rem", background: "#ffdad6", borderRadius: "16px", color: "#ba1a1a", fontWeight: 600 }}>
+            {error || "Élection introuvable."}
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  if (step === "success") {
+    return (
+      <div style={{ background: "#fcf9f4", minHeight: "100vh", fontFamily: "Manrope, sans-serif", color: "#1c1c19" }}>
+        <VoterSidebar user={user} activePath={location.pathname} />
+        <main style={{ marginLeft: "256px", padding: "2rem", display: "flex", alignItems: "center", justifyContent: "center", minHeight: "100vh" }}>
+          <div style={{ background: "#ffffff", borderRadius: "24px", padding: "3rem", boxShadow: "0 4px 32px rgba(10,22,40,0.08)", maxWidth: "520px", width: "100%", textAlign: "center" }}>
+            <div style={{ width: "80px", height: "80px", borderRadius: "50%", background: "#f0fdf4", display: "flex", alignItems: "center", justifyContent: "center", margin: "0 auto 1.5rem" }}>
+              <span className="material-symbols-outlined" style={{ fontSize: "48px", color: "#006e2e" }}>verified</span>
+            </div>
+            <h2 style={{ fontFamily: "Plus Jakarta Sans, sans-serif", fontSize: "1.75rem", fontWeight: 800, color: "#1c1c19", margin: "0 0 0.75rem", letterSpacing: "-0.02em" }}>
+              Vote enregistré !
+            </h2>
+            <p style={{ color: "#535f74", fontWeight: 500, lineHeight: 1.7, margin: "0 0 2rem" }}>
+              Votre vote a été enregistré avec succès et de façon sécurisée.
+            </p>
+
+            {receiptCode && (
+              <div style={{ background: "#fff3cd", border: "1px solid #f5c842", borderRadius: "14px", padding: "1rem 1.25rem", marginBottom: "2rem", textAlign: "left" }}>
+                <p style={{ fontSize: "0.7rem", fontWeight: 700, color: "#7a5c00", textTransform: "uppercase", letterSpacing: "0.1em", margin: "0 0 6px" }}>
+                  Code de reçu
+                </p>
+                <p style={{ fontFamily: "DM Mono, monospace", fontSize: "0.875rem", fontWeight: 600, color: "#1c1c19", margin: 0, wordBreak: "break-all" }}>
+                  {receiptCode}
+                </p>
+              </div>
+            )}
+
+            <button
+              onClick={() => navigate("/elections")}
+              style={{ width: "100%", padding: "14px", background: "#006e2e", border: "none", borderRadius: "14px", color: "#ffffff", fontFamily: "Manrope, sans-serif", fontWeight: 700, fontSize: "0.9rem", cursor: "pointer" }}
+            >
+              Retour à mes élections
+            </button>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ background: "#fcf9f4", minHeight: "100vh", fontFamily: "Manrope, sans-serif", color: "#1c1c19" }}>
+      <VoterSidebar user={user} activePath={location.pathname} />
+
+      <main style={{ marginLeft: "256px", padding: "2rem", minHeight: "100vh" }}>
+
+        {/* Header */}
+        <header style={{ marginBottom: "2rem" }}>
+          <button
+            onClick={() => navigate("/elections")}
+            style={{ display: "inline-flex", alignItems: "center", gap: "6px", background: "none", border: "none", color: "#535f74", fontFamily: "Manrope, sans-serif", fontWeight: 600, fontSize: "0.8rem", cursor: "pointer", padding: "0 0 1rem", marginBottom: "0.5rem" }}
+          >
+            <span className="material-symbols-outlined" style={{ fontSize: "16px" }}>arrow_back</span>
+            Retour aux élections
+          </button>
+          <span style={{ display: "block", fontSize: "0.65rem", fontWeight: 700, color: "#006e2e", letterSpacing: "0.2em", textTransform: "uppercase", marginBottom: "8px" }}>
+            Bulletin de Vote
+          </span>
+          <h2 style={{ fontFamily: "Plus Jakarta Sans, sans-serif", fontSize: "2rem", fontWeight: 800, color: "#1c1c19", margin: "0 0 8px", letterSpacing: "-0.02em" }}>
+            {election.title}
+          </h2>
+        </header>
+
+        {/* Election info card */}
+        <div style={{ background: "#ffffff", borderRadius: "20px", padding: "1.5rem", boxShadow: "0 4px 16px rgba(10,22,40,0.05)", marginBottom: "2rem", display: "flex", flexWrap: "wrap", gap: "1rem", alignItems: "center" }}>
+          <span style={{ fontSize: "0.75rem", fontWeight: 700, color: "#954a00", background: "#fff7ed", padding: "4px 12px", borderRadius: "9999px" }}>
+            {TYPE_LABELS[election.type] ?? election.type}
+          </span>
+          <span style={{ display: "inline-flex", alignItems: "center", gap: "6px", fontSize: "0.75rem", fontWeight: 700, color: "#007432", background: "#f0fdf4", padding: "4px 12px", borderRadius: "9999px" }}>
+            <span style={{ width: "6px", height: "6px", borderRadius: "50%", background: "#007432", display: "inline-block" }} />
+            En cours
+          </span>
+          <span style={{ display: "inline-flex", alignItems: "center", gap: "6px", fontSize: "0.8rem", color: "#535f74" }}>
+            <span className="material-symbols-outlined" style={{ fontSize: "16px" }}>location_on</span>
+            {SCOPE_LABELS[election.geographic_scope] ?? election.geographic_scope}
+          </span>
+          <span style={{ display: "inline-flex", alignItems: "center", gap: "6px", fontSize: "0.8rem", color: "#535f74" }}>
+            <span className="material-symbols-outlined" style={{ fontSize: "16px" }}>schedule</span>
+            {fmtDateTime(election.start_time)} → {fmtDateTime(election.end_time)}
+          </span>
+        </div>
+
+        {/* Already voted guard */}
+        {election.already_voted && (
+          <div style={{ display: "flex", alignItems: "center", gap: "12px", padding: "1.25rem 1.5rem", background: "#f0fdf4", borderRadius: "16px", border: "1px solid #bbf7d0", marginBottom: "2rem" }}>
+            <span className="material-symbols-outlined" style={{ fontSize: "28px", color: "#006e2e" }}>verified</span>
+            <div>
+              <p style={{ fontWeight: 700, color: "#006e2e", margin: "0 0 2px" }}>Vous avez déjà voté</p>
+              <p style={{ fontSize: "0.85rem", color: "#535f74", margin: 0 }}>Votre vote pour cette élection a bien été enregistré.</p>
+            </div>
+          </div>
+        )}
+
+        {/* Cannot vote guard */}
+        {!election.can_vote && !election.already_voted && (
+          <div style={{ display: "flex", alignItems: "center", gap: "12px", padding: "1.25rem 1.5rem", background: "#f6f3ee", borderRadius: "16px", border: "1px solid #e2ddd6", marginBottom: "2rem" }}>
+            <span className="material-symbols-outlined" style={{ fontSize: "28px", color: "#94a3b8" }}>schedule</span>
+            <div>
+              <p style={{ fontWeight: 700, color: "#535f74", margin: "0 0 2px" }}>Ce vote n'est pas encore ouvert</p>
+              <p style={{ fontSize: "0.85rem", color: "#94a3b8", margin: 0 }}>La période de vote n'a pas encore commencé.</p>
+            </div>
+          </div>
+        )}
+
+        {/* Confirmation panel */}
+        {step === "confirm" && selected && (
+          <div style={{ background: "#ffffff", borderRadius: "20px", padding: "2rem", boxShadow: "0 8px 32px rgba(10,22,40,0.10)", marginBottom: "2rem", maxWidth: "520px", border: "2px solid #006e2e" }}>
+            <h3 style={{ fontFamily: "Plus Jakarta Sans, sans-serif", fontSize: "1.1rem", fontWeight: 800, color: "#1c1c19", margin: "0 0 1rem" }}>
+              Confirmer votre vote
+            </h3>
+            <p style={{ color: "#535f74", fontWeight: 500, lineHeight: 1.7, margin: "0 0 1.5rem" }}>
+              Vous êtes sur le point de voter pour{" "}
+              <strong style={{ color: "#1c1c19" }}>{selected.first_name} {selected.last_name}</strong>
+              {selected.party && (
+                <> (<span style={{ color: "#006e2e" }}>{selected.party.name}</span>)</>
+              )}.
+              {" "}Cette action est <strong>irréversible</strong>.
+            </p>
+
+            {submitError && (
+              <div style={{ padding: "12px 16px", background: "#ffdad6", borderRadius: "12px", color: "#ba1a1a", fontWeight: 600, fontSize: "0.875rem", marginBottom: "1rem" }}>
+                {submitError}
+              </div>
+            )}
+
+            <div style={{ display: "flex", gap: "12px" }}>
+              <button
+                onClick={() => { setStep("select"); setSubmitError(""); }}
+                disabled={submitting}
+                style={{ flex: 1, padding: "13px", border: "1.5px solid #dde5ec", borderRadius: "14px", background: "#ffffff", color: "#535f74", fontFamily: "Manrope, sans-serif", fontWeight: 700, fontSize: "0.875rem", cursor: submitting ? "not-allowed" : "pointer", opacity: submitting ? 0.6 : 1 }}
+              >
+                Annuler
+              </button>
+              <button
+                onClick={handleConfirm}
+                disabled={submitting}
+                style={{ flex: 2, padding: "13px", border: "none", borderRadius: "14px", background: submitting ? "#e8954a" : "#f77f00", color: "#ffffff", fontFamily: "Manrope, sans-serif", fontWeight: 700, fontSize: "0.875rem", cursor: submitting ? "not-allowed" : "pointer", boxShadow: "0 4px 12px rgba(247,127,0,0.3)", display: "flex", alignItems: "center", justifyContent: "center", gap: "8px" }}
+              >
+                {submitting ? (
+                  <>
+                    <span style={{ width: "16px", height: "16px", border: "2px solid rgba(255,255,255,0.4)", borderTopColor: "#ffffff", borderRadius: "50%", display: "inline-block", animation: "spin 0.7s linear infinite" }} />
+                    Enregistrement…
+                  </>
+                ) : (
+                  <>
+                    <span className="material-symbols-outlined" style={{ fontSize: "18px" }}>how_to_vote</span>
+                    Confirmer mon vote
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Candidate grid — only when can vote and not yet voted */}
+        {election.can_vote && !election.already_voted && (
+          <>
+            <div style={{ marginBottom: "1rem" }}>
+              <h3 style={{ fontFamily: "Plus Jakarta Sans, sans-serif", fontSize: "1.1rem", fontWeight: 800, color: "#1c1c19", margin: "0 0 4px" }}>
+                Choisissez votre candidat
+              </h3>
+              <p style={{ fontSize: "0.85rem", color: "#535f74", margin: 0 }}>
+                {election.candidates.length} candidat{election.candidates.length !== 1 ? "s" : ""} en lice. Cliquez sur un candidat pour voter.
+              </p>
+            </div>
+
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: "1.25rem" }}>
+              {election.candidates.map(c => (
+                <CandidateCard
+                  key={c.id}
+                  candidate={c}
+                  isSelected={selected?.id === c.id && step === "confirm"}
+                  isHovered={hoveredId === c.id}
+                  onHover={setHoveredId}
+                  onSelect={handleSelectCandidate}
+                />
+              ))}
+            </div>
+          </>
+        )}
+
+        <style>{`
+          @keyframes spin { to { transform: rotate(360deg); } }
+        `}</style>
+      </main>
+    </div>
+  );
+}
+
+function CandidateCard({
+  candidate,
+  isSelected,
+  isHovered,
+  onHover,
+  onSelect,
+}: {
+  candidate: Candidate;
+  isSelected: boolean;
+  isHovered: boolean;
+  onHover: (id: string | null) => void;
+  onSelect: (c: Candidate) => void;
+}) {
+  const initials = `${candidate.first_name[0] ?? ""}${candidate.last_name[0] ?? ""}`.toUpperCase();
+  const highlighted = isSelected || isHovered;
+
+  return (
+    <div
+      onClick={() => onSelect(candidate)}
+      onMouseEnter={() => onHover(candidate.id)}
+      onMouseLeave={() => onHover(null)}
+      style={{
+        background: "#ffffff",
+        borderRadius: "20px",
+        padding: "1.5rem",
+        boxShadow: highlighted ? "0 8px 24px rgba(0,110,46,0.15)" : "0 4px 16px rgba(10,22,40,0.05)",
+        border: `2px solid ${isSelected ? "#006e2e" : isHovered ? "rgba(0,110,46,0.4)" : "transparent"}`,
+        cursor: "pointer",
+        display: "flex",
+        flexDirection: "column" as const,
+        gap: "1rem",
+        transition: "box-shadow 0.15s ease, border-color 0.15s ease",
+      }}
+    >
+      {/* Avatar + name */}
+      <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
+        {candidate.photo_url ? (
+          <img
+            src={candidate.photo_url}
+            alt={`${candidate.first_name} ${candidate.last_name}`}
+            style={{ width: "56px", height: "56px", borderRadius: "50%", objectFit: "cover", flexShrink: 0, border: "2px solid #f6f3ee" }}
+          />
+        ) : (
+          <div style={{ width: "56px", height: "56px", borderRadius: "50%", background: isSelected ? "#006e2e" : "#f6f3ee", display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0, transition: "background 0.15s ease" }}>
+            <span style={{ fontFamily: "Plus Jakarta Sans, sans-serif", fontWeight: 800, fontSize: "1.1rem", color: isSelected ? "#ffffff" : "#535f74" }}>
+              {initials}
+            </span>
+          </div>
+        )}
+        <div style={{ minWidth: 0 }}>
+          <p style={{ fontFamily: "Plus Jakarta Sans, sans-serif", fontWeight: 800, fontSize: "1rem", color: "#1c1c19", margin: "0 0 3px", lineHeight: 1.2 }}>
+            {candidate.first_name} {candidate.last_name}
+          </p>
+          {candidate.party && (
+            <span style={{ fontSize: "0.72rem", fontWeight: 700, color: "#006e2e", background: "#f0fdf4", padding: "2px 8px", borderRadius: "9999px", whiteSpace: "nowrap" as const }}>
+              {candidate.party.acronym ?? candidate.party.name}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Party full name */}
+      {candidate.party && (
+        <p style={{ fontSize: "0.8rem", color: "#535f74", margin: 0, fontWeight: 500 }}>
+          {candidate.party.name}
+        </p>
+      )}
+
+      {/* Biography snippet */}
+      {candidate.biography && (
+        <p style={{ fontSize: "0.8rem", color: "#94a3b8", margin: 0, lineHeight: 1.6 }}>
+          {candidate.biography.slice(0, 120)}{candidate.biography.length > 120 ? "…" : ""}
+        </p>
+      )}
+
+      {/* Vote indicator */}
+      <div style={{ borderTop: "1px solid #f6f3ee", paddingTop: "0.75rem", display: "flex", alignItems: "center", justifyContent: "center", gap: "6px" }}>
+        {isSelected ? (
+          <>
+            <span className="material-symbols-outlined" style={{ fontSize: "18px", color: "#006e2e" }}>check_circle</span>
+            <span style={{ fontSize: "0.8rem", fontWeight: 700, color: "#006e2e" }}>Sélectionné</span>
+          </>
+        ) : (
+          <span style={{ fontSize: "0.8rem", fontWeight: 600, color: isHovered ? "#006e2e" : "#94a3b8" }}>
+            {isHovered ? "Cliquer pour sélectionner" : "Voter pour ce candidat"}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/routes.ts
+++ b/frontend/app/routes.ts
@@ -9,4 +9,5 @@ export default [
   route("admin/elections/:id/candidates", "routes/admin/election-candidates.tsx"),
   route("admin/parties", "routes/admin/parties.tsx"),
   route("elections", "routes/elections.tsx"),
+  route("elections/:id/vote", "routes/election-vote.tsx"),
 ] satisfies RouteConfig;

--- a/frontend/app/routes/election-vote.tsx
+++ b/frontend/app/routes/election-vote.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router";
+import VoterBallot from "../features/dashboard/VoterBallot.js";
+
+interface VotiUser {
+  email: string;
+  role: "ADMIN" | "VOTER" | "OBSERVER";
+  first_name?: string;
+  last_name?: string;
+}
+
+export default function ElectionVoteRoute() {
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const [user, setUser] = useState<VotiUser | null>(null);
+
+  useEffect(() => {
+    const raw = localStorage.getItem("voti_user") ?? localStorage.getItem("agora_user");
+    if (!raw) { navigate("/login"); return; }
+    try {
+      const parsed = JSON.parse(raw) as VotiUser;
+      if (typeof parsed?.email !== "string" || !parsed.email) { navigate("/login"); return; }
+      if (parsed.role !== "VOTER") { navigate("/dashboard"); return; }
+      setUser(parsed);
+    } catch {
+      navigate("/login");
+    }
+  }, [navigate]);
+
+  if (!user || !id) return null;
+  return <VoterBallot electionId={id} user={user} />;
+}


### PR DESCRIPTION
Add the /elections/:id/vote route and ballot UI so voters can navigate
from "Voter maintenant" to a full ballot page, select a candidate,
confirm their choice, and receive a vote receipt code.

- routes.ts: register elections/:id/vote route
- election-vote.tsx: auth-guarded route wrapper (VOTER role only)
- VoterBallot.tsx: 3-step UI (select → confirm → success) with guards
  for already_voted and !can_vote states; calls existing backend
  POST /elections/:id/vote and displays the receipt_code on success

https://claude.ai/code/session_012wnH1yg83L9udjBiSf6FmM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dedicated voting interface with a multi-step flow: candidate selection → confirmation → success
  * Two-column candidate grid with selection and hover highlighting
  * Users receive a receipt code after a successful vote
  * Voter validation and access controls with clear error/“election introuvable” states
  * Direct route to vote pages (elections/:id/vote)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->